### PR TITLE
fix: code sample and test Python 3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Using the standard API
 
     from stockfighter import Stockfighter
     s = Stockfighter(venue='TESTEX', account='EXB123456')
-    print s.venue_stocks()
+    print(s.venue_stocks())
 
 ...and the GM API for managing levels and such
 

--- a/tests/test_stockfighter.py
+++ b/tests/test_stockfighter.py
@@ -49,7 +49,7 @@ def test_readme():
     """Test the content of the README works as advertised."""
     from stockfighter import Stockfighter
     s = Stockfighter(venue='TESTEX', account='EXB123456')
-    print s.venue_stocks()
+    print(s.venue_stocks())
 
     from stockfighter import GM
     gm = GM()


### PR DESCRIPTION
Failing on a "print" statement, bracket it correctly to pass both on Python 2 and 3. Updated both in test and Readme for consistency.
