### PR TITLE
Include authorization header in request for status_for_order()

### DIFF
--- a/stockfighter/stockfighter.py
+++ b/stockfighter/stockfighter.py
@@ -101,7 +101,7 @@ class Stockfighter(object):
             order_id=order_id,
         )
         url = urljoin(self.base_url, url_fragment)
-        return requests.get(url).json()
+        return requests.get(url, headers=self.headers).json()
 
     def cancel_order(self, order_id, stock):
         """Cancel An Order


### PR DESCRIPTION
`Stockfighter.status_for_order(stock)` currently fails because the `X-Starfighter-Authentication` header is not included:

```
{u'ok': False, u'error': u'Auth/auth failed: %!(EXTRA string=Need to specify an API key (looks like a long hexidecimal string.))'}
```
